### PR TITLE
fix(Core/LootMgr): Improved item drop checks for items that start quests

### DIFF
--- a/src/server/game/Loot/LootMgr.cpp
+++ b/src/server/game/Loot/LootMgr.cpp
@@ -468,9 +468,20 @@ bool LootItem::AllowedForPlayer(Player const* player, ObjectGuid source) const
     }
 
     // check quest requirements
-    if (!(pProto->FlagsCu & ITEM_FLAGS_CU_IGNORE_QUEST_STATUS) && ((needs_quest || (pProto->StartQuest && player->GetQuestStatus(pProto->StartQuest) != QUEST_STATUS_NONE)) && !player->HasQuestForItem(itemid)))
+    if (!(pProto->FlagsCu & ITEM_FLAGS_CU_IGNORE_QUEST_STATUS))
     {
-        return false;
+        //  Don't drop quest items if the player is missing the relevant quest
+        if (needs_quest && !player->HasQuestForItem(itemid))
+            return false;
+
+        // for items that start quests
+        if (pProto->StartQuest)
+        {
+            // Don't drop the item if the player has already finished the quest OR player already has the item in their inventory OR the player has not finished a prerequisite quest
+            uint32 prevQuestId = sObjectMgr->GetQuestTemplate(pProto->StartQuest) ? sObjectMgr->GetQuestTemplate(pProto->StartQuest)->GetPrevQuestId() : 0;
+            if (player->GetQuestStatus(pProto->StartQuest) != QUEST_STATUS_NONE || player->HasItemCount(itemid) || (prevQuestId && !player->GetQuestRewardStatus(prevQuestId)))
+                return false;
+        }
     }
 
     if (!sScriptMgr->OnAllowedForPlayerLootCheck(player, source))


### PR DESCRIPTION
## Changes Proposed:
Items that start quest currently drop in cases when they should not. This commit improves the checks and conditions that determine whether an item that starts a quest should drop. Specifically items that start quests incorrectly drop when:
- The player already has the item in their inventory
- The player has not finished a prerequisite quest

This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

I tested this using:
https://www.wowhead.com/wotlk/item=13920
https://www.wowhead.com/wotlk/item=20741

## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
